### PR TITLE
Allow newer version of Buzz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ php:
  - 5.3
  - 5.4
  - 5.5
+env:
+ - BUZZ_VERSION="0.7"
+ - BUZZ_VERSION="0.8"
+ - BUZZ_VERSION="0.9"
 before_script:
-    - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev install
+ - composer require kriswallsmith/buzz:${BUZZ_VERSION}
+ - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev install
 script: "phpunit -c test/phpunit.dist.xml"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "kriswallsmith/buzz": "0.7"
+        "kriswallsmith/buzz": "=>0.7,<=0.9"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "kriswallsmith/buzz": "=>0.7,<=0.9"
+        "kriswallsmith/buzz": ">=0.7,<=0.9"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
This pull request adjust the version constraint in `composer.json` for `krisswallsmith/buzz`, and adjusts the Travis CI configuration, so that versions 0.7, 0.8 and 0.9 of Buzz are allowed and will all used for the unit tests.
