### PR TITLE
Allow Buzz v0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
  - BUZZ_VERSION="0.7"
  - BUZZ_VERSION="0.8"
  - BUZZ_VERSION="0.9"
+ - BUZZ_VERSION="0.10"
 before_script:
  - composer require kriswallsmith/buzz:${BUZZ_VERSION} --no-update
  - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev --no-interaction install

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "kriswallsmith/buzz": ">=0.7,<=0.9"
+        "kriswallsmith/buzz": ">=0.7,<=0.10"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
Increased the maximum version number for Buzz in `composer.json`.
Added Buzz v0.10 to Travis CI configuration, so it will be used when executing the unit tests.
